### PR TITLE
handle proxy errors (&log to stderr)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,10 @@ var config = require('./config')
 
 var proxy = httpProxy.createProxyServer({})
 
+proxy.on('error', function (err) {
+  console.error(err)
+})
+
 var server = http.createServer(function (req, res) {
   if (config.whitelist) {
     var path = req.url


### PR DESCRIPTION
accessing whitelisted path on unreachable upstream leads to uncaught exception. handling errors prevents that.

https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/index.js#L120